### PR TITLE
Fix heartrate obtaining for reverted health service

### DIFF
--- a/src/c/health.c
+++ b/src/c/health.c
@@ -39,7 +39,10 @@ static void health_event_handler(HealthEventType event, void *context) {
         s_distance_walked = get_health_value_sum_today(HealthMetricWalkedDistanceMeters);
         s_steps = get_health_value_sum_today(HealthMetricStepCount);
     } else if (event == HealthEventHeartRateUpdate) {
-        s_heart_rate = is_health_metric_accessible(HealthMetricHeartRateBPM) ? health_service_peek_current_value(HealthMetricHeartRateBPM) : 0;
+        HealthServiceAccessibilityMask hr = health_service_metric_accessible(HealthMetricHeartRateBPM, time(NULL), time(NULL));
+        if (hr & HealthServiceAccessibilityMaskAvailable) {
+            s_heart_rate = health_service_peek_current_value(HealthMetricHeartRateBPM);
+        }
     }
 
     if (s_health_event_callback) s_health_event_callback();


### PR DESCRIPTION
Hello!
I think you make this https://github.com/freakified/TimeStylePebble/commit/edeffd3b88189bd567a53771a7e26e7d2478bb71 revert, because heartrate data was not obtaining as it must. (because it was not obtaining on my pebble 2 for example)
I think this health service is good, because it make watchface more functional, when pebble disconnected from mobile app. Without this health service your watchface don't show steps and heartrate in airplane mode for example. With health service and my fix it works nice.