### PR TITLE
increment failures track before retrying call

### DIFF
--- a/src/pkjs/weather.js
+++ b/src/pkjs/weather.js
@@ -105,9 +105,9 @@ function locationError(err) {
     // reset cache time
     window.localStorage.setItem('weather_loc_cache_time', (new Date().getTime() / 1000));
 
+    currentFailures++;
     // try again
     updateWeather();
-    currentFailures++;
   } else {
     // until we get too many failures, at which point give up
     currentFailures = 0;


### PR DESCRIPTION
Fixing "Maximum call stack size exceeded" error in case of perpetual failures.