### PR TITLE
Add Decimal Internet Time widget

### DIFF
--- a/src/c/settings.c
+++ b/src/c/settings.c
@@ -167,6 +167,7 @@ void Settings_updateDynamicSettings() {
   globalSettings.updateScreenEverySecond = false;
   globalSettings.enableAutoBatteryWidget = true;
   globalSettings.enableBeats = false;
+  globalSettings.enableDIT = false;
   globalSettings.enableAltTimeZone = false;
 
   for(int i = 0; i < 3; i++) {
@@ -190,6 +191,11 @@ void Settings_updateDynamicSettings() {
     // if any widget is "beats", enable the beats calculation
     if(globalSettings.widgets[i] == BEATS) {
       globalSettings.enableBeats = true;
+    }
+
+    // if any widget is "DIT", enable the beats calculation
+    if(globalSettings.widgets[i] == DIT) {
+      globalSettings.enableDIT = true;
     }
 
     // if any widget is "alt_time_zone", enable the alternative time calculation

--- a/src/c/settings.h
+++ b/src/c/settings.h
@@ -34,7 +34,7 @@ typedef struct {
   bool sidebarOnLeft;
   bool useLargeFonts;
   bool activateDisconnectIcon;
-  
+
   // weather widget settings
   bool useMetric;
 
@@ -56,6 +56,7 @@ typedef struct {
   bool updateScreenEverySecond;
   bool enableAutoBatteryWidget;
   bool enableBeats;
+  bool enableDIT;
   bool enableAltTimeZone;
 
   // TODO: these shouldn't be dynamic

--- a/src/c/sidebar_widgets.c
+++ b/src/c/sidebar_widgets.c
@@ -30,6 +30,7 @@ char currentWeekNum[5];
 char currentSecondsNum[5];
 char altClock[8];
 char currentBeats[5];
+char currentDit[6];
 
 // the widgets
 SidebarWidget batteryMeterWidget;
@@ -71,6 +72,10 @@ void AltTime_draw(GContext* ctx, int yPosition);
 SidebarWidget beatsWidget;
 int Beats_getHeight();
 void Beats_draw(GContext* ctx, int yPosition);
+
+SidebarWidget DITWidget;
+int DIT_getHeight();
+void DIT_draw(GContext* ctx, int yPosition);
 
 #ifdef PBL_HEALTH
   GDrawCommandImage* sleepImage;
@@ -137,7 +142,7 @@ void SidebarWidgets_init() {
   #ifdef PBL_HEALTH
     healthWidget.getHeight = Health_getHeight;
     healthWidget.draw = Health_draw;
-    
+
     heartRateWidget.getHeight = HeartRate_getHeight;
     heartRateWidget.draw = HeartRate_draw;
   #endif
@@ -145,6 +150,8 @@ void SidebarWidgets_init() {
   beatsWidget.getHeight = Beats_getHeight;
   beatsWidget.draw      = Beats_draw;
 
+  DITWidget.getHeight   = DIT_getHeight;
+  DITWidget.draw        = DIT_draw;
 }
 
 void SidebarWidgets_deinit() {
@@ -229,8 +236,13 @@ void SidebarWidgets_updateTime(struct tm* timeInfo) {
 
     // set the swatch internet time beats
     beats = time_get_beats(timeInfo);
-  
+
     snprintf(currentBeats, sizeof(currentBeats), "%i", beats);
+  }
+
+  if (globalSettings.enableDIT) {
+      int desims = time_get_dit(timeInfo);
+      snprintf(currentDit, sizeof(currentDit), "%i.%02i", desims / 100, desims % 100);
   }
 }
 
@@ -268,6 +280,9 @@ SidebarWidget getSidebarWidgetByType(SidebarWidgetType type) {
     #endif
     case BEATS:
       return beatsWidget;
+    case DIT:
+      return DITWidget;
+
     default:
       return emptyWidget;
       break;
@@ -899,6 +914,34 @@ void Beats_draw(GContext* ctx, int yPosition) {
                      currentBeats,
                      currentSidebarFont,
                      GRect(SidebarWidgets_xOffset, yPosition + yMod, 30, 20),
+                     GTextOverflowModeFill,
+                     GTextAlignmentCenter,
+                     NULL);
+}
+
+/***** DIT (Decimal Internet Time) widget *****/
+
+int DIT_getHeight() {
+  return (globalSettings.useLargeFonts) ? 29 : 26;
+}
+
+void DIT_draw(GContext* ctx, int yPosition) {
+  graphics_context_set_text_color(ctx, globalSettings.sidebarTextColor);
+
+  graphics_draw_text(ctx,
+                     "DIT",
+                     smSidebarFont,
+                     GRect(SidebarWidgets_xOffset, yPosition - 5, 30, 20),
+                     GTextOverflowModeFill,
+                     GTextAlignmentCenter,
+                     NULL);
+
+  int yMod = (globalSettings.useLargeFonts) ? 5 : 8;
+
+  graphics_draw_text(ctx,
+                     currentDit,
+                     currentSidebarFont,
+                     GRect(SidebarWidgets_xOffset-2, yPosition + yMod, 34, 20),
                      GTextOverflowModeFill,
                      GTextAlignmentCenter,
                      NULL);

--- a/src/c/sidebar_widgets.h
+++ b/src/c/sidebar_widgets.h
@@ -31,7 +31,8 @@ typedef enum {
   TIME_UNUSED               = 9,
   HEALTH                    = 10,
   BEATS                     = 11,
-  HEARTRATE                 = 12
+  HEARTRATE                 = 12,
+  DIT                       = 13
 } SidebarWidgetType;
 
 typedef struct {

--- a/src/c/util.c
+++ b/src/c/util.c
@@ -1,21 +1,6 @@
 #include <pebble.h>
 #include "util.h"
 
-#include <inttypes.h>
-#include <time.h>
-#include <stdio.h>
-#define MS_PER_SEC 1000
-#define MS_PER_MIN (MS_PER_SEC * 60)
-#define MS_PER_HOUR (MS_PER_MIN * 60)
-#define DESECS_PER_DESIM 100
-#define DESIMS_PER_DECA 100
-#define DECAS_PER_DAY 10
-#define DESECS_PER_DECA (DESECS_PER_DESIM * DESIMS_PER_DECA)
-#define DESECS_PER_DAY (DESECS_PER_DECA * DECAS_PER_DAY)
-// 86400 seconds in a day; 100000 desecs in a day; therefore 864 milliseconds per desec, computed by compiler.
-#define MS_PER_DESEC ((1000 * 86400)/DESECS_PER_DAY)
-
-
 bool recolor_iterator_cb(GDrawCommand *command, uint32_t index, void *context) {
   GColor *colors = (GColor *)context;
 
@@ -46,6 +31,19 @@ int time_get_beats(const struct tm *tm) {
 
   return beats;
 }
+
+
+// DIT calc defines
+#define MS_PER_SEC 1000
+#define MS_PER_MIN (MS_PER_SEC * 60)
+#define MS_PER_HOUR (MS_PER_MIN * 60)
+#define DESECS_PER_DESIM 100
+#define DESIMS_PER_DECA 100
+#define DECAS_PER_DAY 10
+#define DESECS_PER_DECA (DESECS_PER_DESIM * DESIMS_PER_DECA)
+#define DESECS_PER_DAY (DESECS_PER_DECA * DECAS_PER_DAY)
+// 86400 seconds in a day; 100000 desecs in a day; therefore 864 milliseconds per desec, computed by compiler.
+#define MS_PER_DESEC ((1000 * 86400)/DESECS_PER_DAY)
 
 int time_get_dit(const struct tm *tm) {
     // From https://gitea.s0.is/s0/Dit/src/branch/main/Echo%20scripts/dit-s0.c

--- a/src/c/util.h
+++ b/src/c/util.h
@@ -14,6 +14,9 @@ extern void gdraw_command_image_recolor(GDrawCommandImage *img, GColor fill_colo
  */
 extern int time_get_beats(const struct tm *tm);
 
+// Returns the time in Deca Internet Time, in desims (decimal minutes)
+extern int time_get_dit(const struct tm *tm);
+
 #ifdef PBL_HEALTH
   /*
    * Checks if any of the specified health activites exist in the specified time range


### PR DESCRIPTION
Decimal Internet time is like Beats time but not Switzerland-centred.

The spec can be found here:
https://djeekay.net/dit/