### PR TITLE
Add Apparent (feels like) Temperature option

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
       "WeatherForecastHighTemp",
       "WeatherForecastLowTemp",
       "WeatherUVIndex",
+      "WeatherApparentTemperature",
       "SettingAltClockName",
       "SettingAltClockOffset",
       "SettingDisableAutobattery",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
       "SettingShowLeadingZero",
       "SettingSidebarOnLeft",
       "SettingSidebarTextColor",
+      "SettingUseApparentTemperature",
       "SettingUseLargeFonts",
       "SettingUseMetric",
       "WeatherUseNightIcon",

--- a/src/c/messaging.c
+++ b/src/c/messaging.c
@@ -40,6 +40,14 @@ void inbox_received_callback(DictionaryIterator *iterator, void *context) {
     weatherDataUpdated = true;
   }
 
+  if(dynamicSettings.enableApparentTemperature) {
+    Tuple *weatherAppTemp_tuple = dict_find(iterator, MESSAGE_KEY_WeatherApparentTemperature);
+    if(weatherAppTemp_tuple != NULL) {
+      Weather_weatherInfo.currentTemp = (int)weatherAppTemp_tuple->value->int32;
+      weatherDataUpdated = true;
+    }
+  }
+
   Tuple *weatherConditions_tuple = dict_find(iterator, MESSAGE_KEY_WeatherCondition);
   if(weatherConditions_tuple != NULL) {
     Weather_setCurrentCondition(weatherConditions_tuple->value->int32);

--- a/src/c/messaging.c
+++ b/src/c/messaging.c
@@ -40,7 +40,7 @@ void inbox_received_callback(DictionaryIterator *iterator, void *context) {
     weatherDataUpdated = true;
   }
 
-  if(dynamicSettings.enableApparentTemperature) {
+  if(settings.useApparentTemperature) {
     Tuple *weatherAppTemp_tuple = dict_find(iterator, MESSAGE_KEY_WeatherApparentTemperature);
     if(weatherAppTemp_tuple != NULL) {
       Weather_weatherInfo.currentTemp = (int)weatherAppTemp_tuple->value->int32;
@@ -97,6 +97,7 @@ void inbox_received_callback(DictionaryIterator *iterator, void *context) {
   Tuple *clockFont_tuple = dict_find(iterator, MESSAGE_KEY_SettingClockFontId);
   Tuple *hourlyVibe_tuple = dict_find(iterator, MESSAGE_KEY_SettingHourlyVibe);
   Tuple *useLargeFonts_tuple = dict_find(iterator, MESSAGE_KEY_SettingUseLargeFonts);
+  Tuple *useApparentTemperature_tuple = dict_find(iterator, MESSAGE_KEY_SettingUseApparentTemperature);
 
   Tuple *widget0Id_tuple = dict_find(iterator, MESSAGE_KEY_SettingWidget0ID);
   Tuple *widget1Id_tuple = dict_find(iterator, MESSAGE_KEY_SettingWidget1ID);
@@ -112,7 +113,6 @@ void inbox_received_callback(DictionaryIterator *iterator, void *context) {
   Tuple *autobattery_tuple = dict_find(iterator, MESSAGE_KEY_SettingDisableAutobattery);
 
   Tuple *activateDisconnectIcon_tuple = dict_find(iterator, MESSAGE_KEY_SettingDisconnectIcon);
-
 
   if(timeColor_tuple != NULL) {
     settings.timeColor = GColorFromHEX(timeColor_tuple->value->int32);
@@ -161,6 +161,10 @@ void inbox_received_callback(DictionaryIterator *iterator, void *context) {
 
   if(useLargeFonts_tuple != NULL) {
     settings.useLargeFonts = (bool)useLargeFonts_tuple->value->int8;
+  }
+
+  if(useApparentTemperature_tuple != NULL) {
+    settings.useApparentTemperature = (bool)useApparentTemperature_tuple->value->int8;
   }
 
   if(hourlyVibe_tuple != NULL) {

--- a/src/c/settings.c
+++ b/src/c/settings.c
@@ -75,6 +75,7 @@ void Settings_saveToStorage() {
 
 void Settings_updateDynamicSettings() {
   dynamicSettings.disableWeather = false;
+  dynamicSettings.enableApparentTemperature = false;
   dynamicSettings.updateScreenEverySecond = false;
   dynamicSettings.enableAutoBatteryWidget = true;
   dynamicSettings.enableBeats = false;

--- a/src/c/settings.c
+++ b/src/c/settings.c
@@ -75,7 +75,6 @@ void Settings_saveToStorage() {
 
 void Settings_updateDynamicSettings() {
   dynamicSettings.disableWeather = false;
-  dynamicSettings.enableApparentTemperature = false;
   dynamicSettings.updateScreenEverySecond = false;
   dynamicSettings.enableAutoBatteryWidget = true;
   dynamicSettings.enableBeats = false;

--- a/src/c/settings.h
+++ b/src/c/settings.h
@@ -63,6 +63,7 @@ typedef struct {
 // Dynamic settings (calculated at runtime based on currently-selected widgets)
 typedef struct {
   bool disableWeather;
+  bool enableApparentTemperature;
   bool updateScreenEverySecond;
   bool enableAutoBatteryWidget;
   bool enableBeats;

--- a/src/c/settings.h
+++ b/src/c/settings.h
@@ -58,12 +58,14 @@ typedef struct {
   bool healthUseDistance;
   bool healthUseRestfulSleep;
   char decimalSeparator;
+  
+  // apparent temperature option
+  bool useApparentTemperature;
 } Settings;
 
 // Dynamic settings (calculated at runtime based on currently-selected widgets)
 typedef struct {
   bool disableWeather;
-  bool enableApparentTemperature;
   bool updateScreenEverySecond;
   bool enableAutoBatteryWidget;
   bool enableBeats;

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -1,7 +1,7 @@
 
 var weather = require('./weather');
 
-var CONFIG_VERSION = 9;
+var CONFIG_VERSION = 10;
 // var BASE_CONFIG_URL = 'http://localhost:4000/';
 var BASE_CONFIG_URL = 'http://freakified.github.io/TimeStylePebble/';
 

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -1,7 +1,7 @@
 
 var weather = require('./weather');
 
-var CONFIG_VERSION = 10;
+var CONFIG_VERSION = 9;
 // var BASE_CONFIG_URL = 'http://localhost:4000/';
 var BASE_CONFIG_URL = 'http://freakified.github.io/TimeStylePebble/';
 
@@ -183,6 +183,14 @@ Pebble.addEventListener('webviewclosed', function(e) {
       window.localStorage.setItem('weather_loc', configData.weather_loc);
       window.localStorage.setItem('weather_loc_lat', configData.weather_loc_lat);
       window.localStorage.setItem('weather_loc_lng', configData.weather_loc_lng);
+    }
+
+    if(configData.apparent_temperature_setting) {
+      if(configData.apparent_temperature_setting == 'off') {
+        dict.SettingUseApparentTemperature = 0;
+      } else if(configData.apparent_temperature_setting == 'on') {
+        dict.SettingUseApparentTemperature = 1;
+      }
     }
 
     if(configData.weather_datasource) {

--- a/src/pkjs/weather_openmeteo.js
+++ b/src/pkjs/weather_openmeteo.js
@@ -12,6 +12,7 @@ function getWeatherFromCoords(pos) {
     '&current_weather=true' +
     '&daily=temperature_2m_max,temperature_2m_min,uv_index_max,weathercode' +
     '&hourly=uv_index' +
+    '&minutely_15=apparent_temperature' +
     '&timezone=auto';
 
   console.log(url);
@@ -38,11 +39,8 @@ function getAndSendWeather(url) {
     var forecastLow = Math.round(json.daily.temperature_2m_min[0]);
     var forecastCode = json.daily.weathercode[0];
 
-    function getCurrentUVFromHourly(json) {
+    function getValueFromArrays(times, values) {
       var now = new Date();
-      var times = json.hourly.time;
-      var uvValues = json.hourly.uv_index;
-
       var closestIndex = 0;
       var smallestDiff = Infinity;
 
@@ -54,10 +52,11 @@ function getAndSendWeather(url) {
           closestIndex = i;
         }
       }
-      return Math.round(uvValues[closestIndex]);
+      return Math.round(values[closestIndex]);
     }
 
-    var uvIndex = getCurrentUVFromHourly(json);
+    var uvIndex = getValueFromArrays(json.hourly.time, json.hourly.uv_index);
+    var apparentTemperature = getValueFromArrays(json.minutely_15.time, json.minutely_15.apparent_temperature);
 
     console.log('Forecast high/low: ' + forecastHigh + '/' + forecastLow);
     console.log('Forecast condition code: ' + forecastCode);
@@ -72,7 +71,8 @@ function getAndSendWeather(url) {
       'WeatherForecastHighTemp': forecastHigh,
       'WeatherForecastLowTemp': forecastLow,
       'WeatherForecastCondition': forecastIcon,
-      'WeatherUVIndex': uvIndex
+      'WeatherUVIndex': uvIndex,
+      'WeatherApparentTemperature': apparentTemperature
     };
 
     console.log(JSON.stringify(dictionary));


### PR DESCRIPTION
Adds option to show apparent (feels like) temperature instead of current temperature.

**## Notes to Reviewer**

A matching config site change would be required to set the option (hence the draft request, the feature is done though), I don't think there's any way for me to make that change. I'm also not sure if I made this change in the best way, I just added a bool in DynamicSettings that lets Apparent Temperature overwrite Current Temperature and use the same widget. I first started by creating a new widget, but it seemed like a lot of unnecessary code duplication.

Feel free to let me know if you see anything wrong, or want me to do anything in a different way. I just threw this together, and have only made some simple non-watchface apps before so I could easily have done something wrong.

I did build and install it on my watch with the boolean hardcoded to true and the temperature dropped from -4C to -11C so it seems to be working.

I'm also looking at making a Quiet Time widget that might also require config site changes, in case you wanted to wait for that.