### PR TITLE
Add options for automatic quiet time widget and preferred replacement index (config page)

### DIFF
--- a/_includes/config_common_options.html
+++ b/_includes/config_common_options.html
@@ -62,6 +62,23 @@
   </div>
   <hr>
 </div>
+<div id="widget_quiet_time_settings">
+  <label>Quiet Time</label>
+  <div id="auto_quiet_time_setting" class="form-group" >
+    <label class="subtle">Automatic Quiet Time Notification</label>
+    <div class="btn-group btn-group-justified"  data-toggle="buttons">
+      <label class="btn btn-default" data-setting="on" >
+        <input type="radio" name="options" autocomplete="off">
+        Automatically show when enabled
+      </label>
+      <label class="btn btn-default" data-setting="off" >
+        <input type="radio" name="options" autocomplete="off">
+        Never show
+      </label>
+    </div>
+  </div>
+  <hr>
+</div>
 <div id="widget_weather_settings">
   <label>Weather</label>
   <br>
@@ -232,6 +249,22 @@
     </label>
     <label class="btn btn-default" data-setting="yes" >
       <input type="radio" name="options" autocomplete="off">Vibrate
+    </label>
+  </div>
+</div>
+<hr>
+<label>Automatic Widget Index (Battery/Quiet Time/Bluetooth Disconnection)</label><br>
+<label class="subtle">Preferred Replacement Index</label>
+<div id="auto_replace_index_setting" class="form-group" >
+  <div class="btn-group btn-group-justified"  data-toggle="buttons">
+    <label class="btn btn-default" data-setting="0" >
+      <input type="radio" name="options" autocomplete="off">0
+    </label>
+    <label class="btn btn-default" data-setting="1" >
+      <input type="radio" name="options" autocomplete="off">1
+    </label>
+    <label class="btn btn-default" data-setting="2" >
+      <input type="radio" name="options" autocomplete="off">2
     </label>
   </div>
 </div>


### PR DESCRIPTION
Adds options to show quiet time widget when quiet time is enabled, and to pick which widget is replaced when there are no empty slots.